### PR TITLE
fix: explicitly install dependencies without development in publish

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -27,6 +27,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
-          bundler-cache: true
+          bundler-cache: false
+      - name: Install dependencies without development
+        run: bundle install --without development
       - name: Release gem
         uses: rubygems/release-gem@v1


### PR DESCRIPTION
## Summary
Add explicit `bundle install --without development` step before the release-gem action. The `rubygems/release-gem@v1` action may run `bundle install` internally without respecting the `BUNDLE_WITHOUT` environment variable, causing Rails and other development dependencies to be installed during publishing.

## Changes
- Add explicit bundle install step with --without development flag
- Disable bundler-cache in ruby/setup-ruby to ensure clean install
- Ensures Rails is not installed before release-gem action runs

## Review Focus
- Verify bundle install --without development excludes Rails
- Confirm release-gem action doesn't try to install Rails
- Check that publish workflow completes successfully

## Test Plan
- [ ] Verify bundle install --without development excludes development group
- [ ] Confirm publish workflow doesn't install Rails
- [ ] Test manual workflow_dispatch to verify fix