### PR TITLE
fix: make Rakefile conditional to avoid requiring dev dependencies

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,24 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
-require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new(:spec)
-
-require "rubocop/rake_task"
-
-RuboCop::RakeTask.new do |task|
-  task.options = ["--config", ".rubocop.yml"]
+begin
+  require "rspec/core/rake_task"
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+  # RSpec is in development group, may not be available when BUNDLE_WITHOUT: development
 end
 
-task default: %i[spec rubocop]
+begin
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new do |task|
+    task.options = ["--config", ".rubocop.yml"]
+  end
+rescue LoadError
+  # RuboCop is in development group, may not be available when BUNDLE_WITHOUT: development
+end
+
+default_tasks = []
+default_tasks << :spec if Rake::Task.task_defined?(:spec)
+default_tasks << :rubocop if Rake::Task.task_defined?(:rubocop)
+task default: default_tasks unless default_tasks.empty?


### PR DESCRIPTION
## Summary
Make Rakefile conditionally require RSpec and RuboCop rake tasks. The `rubygems/release-gem@v1` action runs `bundle exec rake release`, which loads the Rakefile. When the Rakefile requires `rspec/core/rake_task` and `rubocop/rake_task` (which are in the development group), Bundler tries to install them and their dependencies (including Rails), even when `BUNDLE_WITHOUT: development` is set.

## Changes
- Wrap RSpec and RuboCop requires in begin/rescue blocks
- Only define tasks if the gems are available
- Make default task conditional on tasks being defined
- Allows `rake release` to run without development dependencies

## Root Cause
The `rubygems/release-gem@v1` action runs `bundle exec rake release` (as seen in its source code). When Ruby loads the Rakefile, it executes the `require` statements, which causes Bundler to try to install those gems even when they're in the development group and `BUNDLE_WITHOUT: development` is set.

## Review Focus
- Verify Rakefile doesn't require dev dependencies when unavailable
- Confirm `rake release` works without RSpec/RuboCop installed
- Check that CI still works (dev dependencies are installed normally)
- Verify publish workflow no longer tries to install Rails

## Test Plan
- [ ] Verify Rakefile loads without RSpec/RuboCop installed
- [ ] Confirm `bundle exec rake release` works with BUNDLE_WITHOUT: development
- [ ] Verify CI workflow still runs tests correctly
- [ ] Test publish workflow doesn't install Rails