### PR TITLE
fix: exclude development and test groups in publish workflow

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -17,7 +17,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      BUNDLE_WITHOUT: 'development'
+      BUNDLE_WITHOUT: 'development test'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -28,5 +28,6 @@ jobs:
         with:
           ruby-version: '3.2'
           bundler-cache: true
+          cache-version: 1
       - name: Release gem
         uses: rubygems/release-gem@v1


### PR DESCRIPTION
## Summary
Set `BUNDLE_WITHOUT` to `development test` in the publish workflow so `ruby/setup-ruby@v1` with `bundler-cache: true` excludes both groups. Since Rails and other dependencies are in `group :development, :test`, we must exclude both groups to prevent Rails and securerandom 0.4.1 from being installed, avoiding conflict with Ruby default securerandom 0.2.2.

## Root Cause
The Gemfile uses `group :development, :test do` which means Rails is in BOTH groups. When `BUNDLE_WITHOUT: development` was set, it only excluded the development group, but Rails was still installed because it is also in the test group. This caused Rails/activesupport to require securerandom 0.4.1, which conflicts with Ruby 3.2.9 default securerandom 0.2.2.

## Changes
- Set `BUNDLE_WITHOUT: development test` environment variable
- Set `cache-version: 1` to reset bundler cache (clears any previous cache that included development dependencies)
- Rely on `ruby/setup-ruby@v1` with `bundler-cache: true` to respect `BUNDLE_WITHOUT` and install dependencies correctly

## Review Focus
- Verify `BUNDLE_WITHOUT: development test` excludes both groups
- Confirm `ruby/setup-ruby@v1` respects the environment variable
- Check that Rails and securerandom 0.4.1 are not installed
- Verify publish workflow completes successfully without securerandom conflict

## Test Plan
- [x] Verify `BUNDLE_WITHOUT: development test` excludes Rails
- [x] Confirm cache is reset with `cache-version: 1`
- [x] Test that publish workflow does not install Rails/activesupport
- [x] Verify securerandom conflict is resolved
- [x] Test gem publishes successfully