### PR TITLE
Add Dependabot configuration for automated updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+---
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - ruby
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      development-dependencies:
+        patterns:
+          - rails
+          - rspec
+          - rubocop*
+        update-types:
+          - minor
+          - patch
+      production-dependencies:
+        patterns:
+          - rack
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: rails
+        update-types:
+          - version-update:semver-major
+      - dependency-name: rack
+        update-types:
+          - version-update:semver-major
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: chore
+      include: scope


### PR DESCRIPTION
## Summary

Adds Dependabot configuration to automatically create pull requests
for dependency updates. This enables weekly automated checks for both
Ruby gem dependencies (via Bundler) and GitHub Actions, reducing
manual maintenance overhead while keeping dependencies up to date.

## Changes

- Add `.github/dependabot.yml` configuration file
- Configure weekly updates for Bundler dependencies (Ruby gems)
- Configure weekly updates for GitHub Actions
- Group development dependencies (Rails, RSpec, RuboCop) to reduce PR noise
- Group production dependencies (Rack) separately
- Ignore major version updates for Rails and Rack to prevent breaking changes
- Set PR limits (10 for Bundler, 5 for GitHub Actions)
- Auto-label PRs with `dependencies` and ecosystem-specific labels
- Configure commit message prefix as `chore` to align with conventional commits

## Review Focus

- Verify Dependabot configuration syntax is correct
- Confirm grouping strategy reduces PR noise appropriately
- Check that major version ignores are appropriate for Rails and Rack
- Ensure schedule (weekly on Mondays) is acceptable
- Validate PR limits prevent overwhelming the repository

## Test Plan

- [x] Verified YAML syntax is valid
- [ ] After merge, verify Dependabot creates PRs for available updates
- [ ] Confirm grouped updates work as expected
- [ ] Verify major version updates are properly ignored
- [ ] Check that PR labels are applied correctly