### PR TITLE
Add RubyGems version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FirebaseHostingClientIp
 
+[![Gem Version](https://badge.fury.io/rb/firebase_hosting_client_ip.svg)](https://badge.fury.io/rb/firebase_hosting_client_ip)
+
 A Rails middleware gem that normalizes client IP addresses when your Rails application is deployed behind Firebase Hosting.
 
 ## Problem


### PR DESCRIPTION
## Summary
Adds a RubyGems version badge to the top of the README. This provides users with immediate visibility of the current gem version and a direct link to the package on rubygems.org, improving discoverability and making it easier for users to find the official gem page.

## Changes
- Add RubyGems version badge using badge.fury.io service
- Badge displays current version (0.3.0) and links to https://rubygems.org/gems/firebase_hosting_client_ip
- Positioned at top of README after title for maximum visibility

## Review Focus
- Badge renders correctly in GitHub markdown
- Link points to correct RubyGems package page

## Test Plan
- [x] Verify badge markdown syntax is correct
- [ ] Check badge displays properly on GitHub
- [ ] Confirm badge links to correct RubyGems page
- [ ] Verify badge shows current version (0.3.0)